### PR TITLE
implement eval function

### DIFF
--- a/src/Embedding.ml
+++ b/src/Embedding.ml
@@ -2,7 +2,7 @@
 
 (* Opening GT yet again. *)
 open GT
-       
+
 (* Opening the substrate module for convenience. *)
 open Expr
 
@@ -12,7 +12,7 @@ let ( !? ) n = Const n
 
 (* Implementation of operators *)
 let binop op x y = Binop (op, x, y)
-                         
+
 let ( +  ) = binop "+"
 let ( -  ) = binop "-"
 let ( *  ) = binop "*"
@@ -34,7 +34,8 @@ let z = !"z"
 let t = !"t"
 
 (* Voila; comment this out before submitting the solution *)
+(*
 let _ =
   List.iter (fun e -> Printf.printf "eval s (%s) = %d\n" (show(expr) e) (eval s e)) [x+y*z- !?3; t-z+y && x]
+*)
 
-                   

--- a/src/Expr.ml
+++ b/src/Expr.ml
@@ -3,14 +3,14 @@
 (* Opening a library for generic programming (https://github.com/dboulytchev/GT).
    The library provides "@type ..." syntax extension and plugins like show, etc.
 *)
-open GT 
-             
-(* The type for the expression. Note, in regular OCaml there is no "@type..." 
-   notation, it came from GT. *)
+open GT
+
+     (* The type for the expression. Note, in regular OCaml there is no "@type..."
+        notation, it came from GT. *)
 @type expr =
-  (* integer constant *) | Const of int
-  (* variable         *) | Var   of string
-  (* binary operator  *) | Binop of string * expr * expr with show
+(* integer constant *) | Const of int
+(* variable         *) | Var   of string
+(* binary operator  *) | Binop of string * expr * expr with show
 
 (* Available binary operators:
     !!                   --- disjunction
@@ -26,28 +26,62 @@ type state = string -> int
 (* Empty state: maps every variable into nothing. *)
 let empty = fun x -> failwith (Printf.sprintf "Undefined variable %s" x)
 
-(* Update: non-destructively "modifies" the state s by binding the variable x 
+(* Update: non-destructively "modifies" the state s by binding the variable x
    to value v and returns the new state.
 *)
 let update x v s = fun y -> if x = y then v else s y
 
-(* An example of a non-trivial state: *)                                                   
+(* An example of a non-trivial state: *)
+
 let s = update "x" 1 @@ update "y" 2 @@ update "z" 3 @@ update "t" 4 empty
 
 (* Some testing; comment this definition out when submitting the solution. *)
+(*
 let _ =
   List.iter
     (fun x ->
        try  Printf.printf "%s=%d\n" x @@ s x
        with Failure s -> Printf.printf "%s\n" s
     ) ["x"; "a"; "y"; "z"; "t"; "b"]
-
+*)
 (* Expression evaluator
 
      val eval : state -> expr -> int
- 
-   Takes a state and an expression, andreturns the value of the expression in 
+
+   Takes a state and an expression, and returns the value of the expression in
    the given state.
 *)
-let eval = failwith "Not implemented yet"
-                    
+let eval s e =
+  let (@.) f g x y = f @@ g x y in
+  let (@..) f g x y = f (g x) (g y) in
+  let bool_of_int x = x != 0 in
+  let int_of_bool x = if x then 1 else 0 in
+  let rec eval s = function
+    | Const x -> x
+    | Var x -> s x
+    | Binop(op, left, right) ->
+      let left = eval s left in
+      let right = eval s right in
+      let op_func =
+        match op with
+        | "+" -> (+)
+        | "-" -> (-)
+        | "*" -> ( * )
+        | "/" -> (/)
+        | "%" -> (mod)
+        | _ ->
+          let bool_op_func =
+            match op with
+            | ">" -> (>)
+            | "<" -> (<)
+            | ">=" -> (>=)
+            | "<=" -> (<=)
+            | "==" -> (==)
+            | "!=" -> (!=)
+            | "!!" -> (||) @.. bool_of_int
+            | "&&" -> (&&) @.. bool_of_int
+            | _ -> failwith "Unsupported operation" in
+          int_of_bool @. bool_op_func in
+      op_func left right in
+  eval s e
+


### PR DESCRIPTION
Semantic description of operators "==" and "!=" is inconsistent. These signs correspond to "==" and "<>" respectively, but in OCaml these operators aren't opposite. It hasn't side effects for int, but it can be important for other types. So in my implementation semantic description of operators "==" and "!=" is "==" and "!=".  

