### PR TITLE
Fixed failing travis-ci build: specified fork of ocaml-ci-scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ sudo: required
 install: wget https://raw.githubusercontent.com/anlun/ocaml-ci-scripts/patch-1/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=4.06
+  - FORK_USER=anlun FORK_BRANCH=patch-1 OCAML_VERSION=4.06
 os:
   - linux


### PR DESCRIPTION
Fixes #80.
Now build script successfully builds everything required to run tests.

during travis-ci build script execution latest version of ".travis-ocaml.sh" script at ocaml/ocaml-ci-scripts/master installs ocaml 4.06.1 which leads to conflict with camlp5 and build failure.
camlp5 in opam repository is still at version 7.3, which requires ocaml version <4.06.1

this commit uses scripts from anlun/ocaml-ci-scripts/patch-1