### PR TITLE
Add .gitignore and default.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.depend
+*.cmi
+*.cmx
+*.opt
+*.o
+*.log

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+with import <nixpkgs> {}; {
+  ocamlEnv = stdenv.mkDerivation {
+    name = "ocamlEnv";
+    buildInputs = [
+      ocaml
+      opam
+      m4
+      ncurses
+    ];
+  };
+}


### PR DESCRIPTION
1. Lack of .gitignore makes it very annoying to manage changes in the repo in the presence of build artifacts. Many people added .gitignore in their forks anyway by themselves.
2. `default.nix` is a file which defines development environment for Nix and NixOS users (https://nixos.org/). Merge it to make NixOS users among students happy for free!