### PR TITLE
Fixed travis job termination because of log size

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -4,12 +4,12 @@ RC=../src/rc.opt
 
 .PHONY: check $(TESTS) 
 
-check: $(TESTS) 
+check: $(TESTS)
 
 $(TESTS): %: %.expr
-	$(RC) $< && cat $@.input | ./$@ > $@.log && diff $@.log orig/$@.log
-	cat $@.input | $(RC) -i $< > $@.log && diff $@.log orig/$@.log
-	cat $@.input | $(RC) -s $< > $@.log && diff $@.log orig/$@.log
+	@$(RC) $< && cat $@.input | ./$@ > $@.log && diff $@.log orig/$@.log
+	@cat $@.input | $(RC) -i $< > $@.log && diff $@.log orig/$@.log
+	@cat $@.input | $(RC) -s $< > $@.log && diff $@.log orig/$@.log
 
 clean:
 	rm -f test*.log *.s *~ $(TESTS)

--- a/regression/deep-expressions/Makefile
+++ b/regression/deep-expressions/Makefile
@@ -7,9 +7,9 @@ RC = ../../src/rc.opt
 check: $(TESTS)
 
 $(TESTS): %: %.expr
-	RC_RUNTIME=../../runtime $(RC) $< && cat $@.input | ./$@ > $@.log && diff $@.log orig/$@.log
-	cat $@.input | $(RC) -i $< > $@.log && diff $@.log orig/$@.log
-	cat $@.input | $(RC) -s $< > $@.log && diff $@.log orig/$@.log
+	@RC_RUNTIME=../../runtime $(RC) $< && cat $@.input | ./$@ > $@.log && diff $@.log orig/$@.log
+	@cat $@.input | $(RC) -i $< > $@.log && diff $@.log orig/$@.log
+	@cat $@.input | $(RC) -s $< > $@.log && diff $@.log orig/$@.log
 
 clean:
 	rm -f *.log *.s *~ $(TESTS)

--- a/regression/expressions/Makefile
+++ b/regression/expressions/Makefile
@@ -7,9 +7,9 @@ RC = ../../src/rc.opt
 check: $(TESTS)
 
 $(TESTS): %: %.expr
-	RC_RUNTIME=../../runtime $(RC) $< && cat $@.input | ./$@ > $@.log && diff $@.log orig/$@.log
-	cat $@.input | $(RC) -i $< > $@.log && diff $@.log orig/$@.log
-	cat $@.input | $(RC) -s $< > $@.log && diff $@.log orig/$@.log
+	@RC_RUNTIME=../../runtime $(RC) $< && cat $@.input | ./$@ > $@.log && diff $@.log orig/$@.log
+	@cat $@.input | $(RC) -i $< > $@.log && diff $@.log orig/$@.log
+	@cat $@.input | $(RC) -s $< > $@.log && diff $@.log orig/$@.log
 
 clean:
 	rm -f *.log *.s *~ $(TESTS)


### PR DESCRIPTION
Excessively verbose makefiles generate logs that are too large for travis, which leads to job termination and build failure. This commit should fix that.