### PR TITLE
Fix of two bugs

### DIFF
--- a/src/X86.ml
+++ b/src/X86.ml
@@ -99,10 +99,10 @@ class env =
     method allocate =    
       let x, n =
 	let rec allocate' = function
-	| []                            -> ebx     , 0
-	| (S n)::_                      -> S (n+1) , n+1
-	| (R n)::_ when n < num_of_regs -> R (n+1) , stack_slots
-	| _                             -> S 0     , 1
+	| []                              -> ebx     , 0
+	| (S n)::_                        -> S (n+1) , n+2
+	| (R n)::_ when n < num_of_regs-1 -> R (n+1) , stack_slots
+	| _                               -> S 0     , 1
 	in
 	allocate' stack
       in


### PR DESCRIPTION
1. env#allocate actually allocate first 4 registers instead of 3 (as described in comment)
2. When `S (n+1)` is allocated it means that there are allocated `n + 2` positions on stack (it is crucial since you can accidentially rewrite the value of top variable of symbolic stack when perform `push` instruction in assembly and vice versa, rewrite top machine stack element while modifying last variable on symbolic stack.